### PR TITLE
Remove dead link, expand on General Job Seeking Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A list of links with resources for Job Seekers.
 
 |                                              **Name**                                               |                         **Description**                          |
 | :-------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------: |
-| [Covintern](https://covintern.com), [gcreddy42/hiring2020](https://github.com/gcreddy42/hiring2020) |        Open-source tracker of companies currently hiring         |
+| [Covintern](https://covintern.com)                                                                  |        Open-source tracker of companies currently hiring         |
 |                       [Remote Students](https://remotestudents.co/#listings)                        |           Listings for remote internships and FT work            |
 |         [Thrive Cash Student Hiring Tracker](https://thrivecash.com/student-hiring-tracker)         | Tracker for internships and FT across many roles (not only tech) |
 |                      [Candor Hiring Tracker](https://candor.co/hiring-freezes)                      |     Candor, a career consultancy, also has a hiring tracker      |
@@ -31,6 +31,39 @@ A list of links with resources for Job Seekers.
 |                                            **Name**                                             |                         **Description**                         |
 | :---------------------------------------------------------------------------------------------: | :-------------------------------------------------------------: |
 | [CS Jobs](https://docs.google.com/document/d/1VL3GqkwWWjXuK6MHGxGq81sOf0GJRr8Gxn5dlcHBXVk/edit) | A  google doc with links to various CS/CS-job related resources. [Archived Copy](./archive/cs%20jobs.docx) |
+
+Popular resources from above
+|                                            **Name**                                             |                         **Description**                         |
+| :---------------------------------------------------------------------------------------------: | :-------------------------------------------------------------: |
+| [levels.fyi](https://www.levels.fyi/) | Salary sharing |
+
+### Programs aimed towards undergrads
+
+|                                            **Name**                                             |                         **Description**                         |
+| :---------------------------------------------------------------------------------------------: | :-------------------------------------------------------------: |
+| [facebook uni](https://www.facebook.com/careers/students-and-grads/students) |  |
+| [google step](https://careers.google.com/jobs/results/?company=Google&company=YouTube&employment_type=INTERN&jlo=en_US&q=STEP&src=Online%2FTOPS%2FTOPS_site&utm_campaign=STEP&utm_medium=site&utm_source=TOPS) |  |
+| [microsoft explore](https://careers.microsoft.com/students/us/en/usexploremicrosoftprogram) |  |
+| [amazon](https://www.amazon.jobs/en/landing_pages/amazonfutureengineer) |  |
+| [pinterest engage](https://www.pinterestcareers.com/jobs/pinterest-engage-scholars-program-san-francisco-california-united-states) |  |
+| [google summer of code](https://summerofcode.withgoogle.com/) |  |
+| [twitter academy](https://twitterudiversity.splashthat.com/) |  |
+| [microsoft garage](https://mcec.microsoft.ca/internships/) |  |
+| [mozilla fix-the-internet](https://builders.mozilla.community/springlab/index.html) |  |
+
+### Online Resume Advice resources
+
+Reddit (requires an account to post)
+|                                              **Subreddit Name**                                     |                         **Notes**                          |
+| :-------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------: |
+| [cscareerquestions](https://www.reddit.com/r/cscareerquestions/search?q=author%3ACSCQMods+Resume+Advice+Thread&restrict_sr=on&sort=new&t=all) | Threads run every tuesday/saturday |
+| [csMajors](https://www.reddit.com/r/csMajors/)                                                      |        Weekly Threads         |
+| [Resume](https://www.reddit.com/r/resumes/search/?sort=new&q=flair%3AComp%2BSci%2B%26%2BIT)         |        General subreddit for all jobs         |
+
+Facebook Groups
+|                                              **Name**                                               |                         **Notes**                          |
+| :-------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------: |
+| [HH Websites and Resumes](https://www.facebook.com/groups/1487708811477672)                         | Requires a facebook account |
 
 ### Contribute to Open Source Projects
 


### PR DESCRIPTION
Add online advice threads, programs aimed towards undergrads from the General Job Seeking Resources

Depending on if the CS Jobs link/any other resource that aggregates information like this gets updated periodically,  future suggestions to this README include 
1. List of companies that have an office in Toronto/Ontario (web scraping is possible but not generally allowed on all career sites (i.e. ip bans if caught doing it often))
2. basic job interview (not coding interviews) overview
2. additional resources to Open source communities/resources to learn/practice skills. This could end up being a separate README file if the lists gets too long over time

Would like to hear your thoughts, thanks.